### PR TITLE
fix: use y instead of a in factoring formula display

### DIFF
--- a/src/problems/Equations.tsx
+++ b/src/problems/Equations.tsx
@@ -526,9 +526,9 @@ const Equations = ({ operator }: { operator: string }) => {
           <>
             {fcformula && (
               <div className="formula-box">
-                <M tex={"x^2 + 2ax + a^2 = (x+a)^2"} />
-                <M tex={"x^2 - 2ax + a^2 = (x-a)^2"} />
-                <M tex={"x^2 - a^2 = (x+a)(x-a)"} />
+                <M tex={"x^2 + 2xy + y^2 = (x+y)^2"} />
+                <M tex={"x^2 - 2xy + y^2 = (x-y)^2"} />
+                <M tex={"x^2 - y^2 = (x+y)(x-y)"} />
                 <M tex={"x^2 + (a+b)x + ab = (x+a)(x+b)"} />
               </div>
             )}


### PR DESCRIPTION
Change the symbol in the factoring formula box from `a` to `y`, matching Japanese curriculum convention and the expansion formulas.

Closes #6

Generated with [Claude Code](https://claude.ai/code)